### PR TITLE
Allow custom min value to be set when scaling indicator values

### DIFF
--- a/indicators/utils.js
+++ b/indicators/utils.js
@@ -4,12 +4,15 @@ function round (value, decimals = 2) {
 
 /**
  * Adds a scaled score to objects (0 - 100). By default it applies a linear
- * scale, though logscale is also available.
+ * scale, though natural logarithm is also available.
  *
- * @param {Array}   data              Data to add the score to.
- * @param {Number}  data[].value      The value to scale.
- * @param {Object}  [options]         Options object.
- * @param {Boolean} [options.log]     Use logscale instead of linear.
+ * @param {Array}   data                Data to add the score to.
+ * @param {Number}  data[].value        The value to scale.
+ * @param {Object}  [options]           Options object.
+ * @param {Boolean} [options.log]       Use logscale instead of linear.
+ * @param {Number}  [options.customMin] Override the min value in the dataset.
+ *                                      By default this is automatically
+ *                                      determined from data[]
  *
  * @example
  * // returns [{'value': 20, 'score': 40}, {'value': 50, 'score': 100}]
@@ -20,21 +23,36 @@ function round (value, decimals = 2) {
  */
 function addScaledScore (data, options = {}) {
   const {
-    log = false
+    log = false,
+    customMin = null
   } = options;
 
   const values = data.map(datum => datum.value).filter(value => !isNaN(value));
 
+  // Override the min value in the dataset.
+  let minValue = customMin !== null
+    ? customMin
+    : Math.min(...values);
+
+  // To avoid issues with natural logarithm, minValue is ensured to be >1
+  if (log && minValue < 1) minValue = 1;
+
   const domain = log
-    ? [Math.log(Math.min(...values)), Math.log(Math.max(...values))]
-    : [Math.min(...values), Math.max(...values)];
+    ? [Math.log(minValue), Math.log(Math.max(...values))]
+    : [minValue, Math.max(...values)];
+
   const range = domain[1] - domain[0];
 
   // Scale values from 0-100
   return data
     .filter(datum => !isNaN(datum.value))
     .map(datum => {
-      const value = log ? Math.log(datum.value) : datum.value;
+      // If custom minValue is set, make sure it's applied
+      let value = datum.value < options.customMin
+        ? options.customMin
+        : datum.value;
+
+      value = log ? Math.log(value) : value;
       return {
         ...datum,
         score: round((value - domain[0]) * 100 / range, 2)

--- a/tests/indicators.test.js
+++ b/tests/indicators.test.js
@@ -31,7 +31,57 @@ describe('Add scaled score to indicators', function () {
     assert.deepEqual(addScaledScore(input, { log: true }), output);
   });
 
-  it('Handles non-numeric values', function () {
+  it('Add correct score using custom min', function () {
+    const input = [
+      { value: 20 },
+      { value: 100 }
+    ];
+    const output = [
+      { value: 20, score: 20 },
+      { value: 100, score: 100 }
+    ];
+    assert.deepEqual(addScaledScore(input, { customMin: 0 }), output);
+  });
+
+  it('Correctly scale when customMin is higher than min value in dataset', function () {
+    const input = [
+      { value: 20 },
+      { value: 55 },
+      { value: 100 }
+    ];
+    const output = [
+      { value: 20, score: 0 },
+      { value: 55, score: 25 },
+      { value: 100, score: 100 }
+    ];
+    assert.deepEqual(addScaledScore(input, { customMin: 40 }), output);
+  });
+
+  it('Correct scale using custom min and logscale', function () {
+    const input = [
+      { value: 20 },
+      { value: 100 }
+    ];
+    const output = [
+      { value: 20, score: 65.05 },
+      { value: 100, score: 100 }
+    ];
+    assert.deepEqual(addScaledScore(input, { log: true, customMin: 1 }), output);
+  });
+
+  it('Correct scale using custom min of 0 and logscale', function () {
+    const input = [
+      { value: 20 },
+      { value: 100 }
+    ];
+    const output = [
+      { value: 20, score: 65.05 },
+      { value: 100, score: 100 }
+    ];
+    assert.deepEqual(addScaledScore(input, { log: true, customMin: 0 }), output);
+  });
+
+  it('Handle non-numeric values', function () {
     const input = [
       { value: 0 },
       { value: 'AmIANumber?' },


### PR DESCRIPTION
Will be used to make sure that AADT of 30 is not treated as 0.